### PR TITLE
fix(android): prevent loss of FCM notifications on cold start (Android S+)

### DIFF
--- a/src/android/FirebasexMessagingPlugin.java
+++ b/src/android/FirebasexMessagingPlugin.java
@@ -97,7 +97,9 @@ public class FirebasexMessagingPlugin extends CordovaPlugin {
             immediateMessagePayloadDelivery = "true".equals(FirebasexCorePlugin.getInstance()
                     .getPluginVariableFromConfigXml("FIREBASE_MESSAGING_IMMEDIATE_PAYLOAD_DELIVERY"));
 
-            // Check for notification from app launch
+            // Check for notification from app launch.
+            // Detect both system-handled notifications (google.message_id in extras)
+            // and notifications routed through OnNotificationReceiverActivity (messageType in extras).
             Bundle extras = cordovaActivity.getIntent().getExtras();
             if (extras != null && extras.size() > 1) {
                 if (notificationStack == null) {
@@ -107,7 +109,23 @@ public class FirebasexMessagingPlugin extends CordovaPlugin {
                     extras.putString("messageType", "notification");
                     extras.putString("tap", "background");
                     notificationStack.add(extras);
-                    Log.d(TAG, "Notification message found on init: " + extras.toString());
+                    Log.d(TAG, "Notification message found on init (google.message_id): " + extras.toString());
+                } else if (extras.containsKey("messageType") && extras.containsKey("tap")) {
+                    // Already processed by OnNotificationReceiverActivity — avoid duplicate
+                    // Only add if not already in the stack (sendMessage may have queued it)
+                    boolean alreadyQueued = false;
+                    if (notificationStack != null) {
+                        for (Bundle b : notificationStack) {
+                            if (b == extras || (extras.getString("id") != null && extras.getString("id").equals(b.getString("id")))) {
+                                alreadyQueued = true;
+                                break;
+                            }
+                        }
+                    }
+                    if (!alreadyQueued) {
+                        notificationStack.add(extras);
+                        Log.d(TAG, "Notification message found on init (messageType+tap): " + extras.toString());
+                    }
                 }
             }
 
@@ -867,16 +885,20 @@ public class FirebasexMessagingPlugin extends CordovaPlugin {
 
     /**
      * Sends any queued notifications to the JS layer.
+     * Takes a snapshot of the pending stack and clears it before iterating,
+     * so that sendMessage() can safely re-queue items without causing
+     * ConcurrentModificationException or data corruption from parallel tasks.
      */
     private synchronized void sendPendingNotifications() {
-        if (notificationStack != null) {
+        if (notificationStack != null && !notificationStack.isEmpty()) {
+            final ArrayList<Bundle> pending = new ArrayList<>(notificationStack);
+            notificationStack.clear();
             this.cordova.getThreadPool().execute(new Runnable() {
                 public void run() {
                     try {
-                        for (Bundle bundle : notificationStack) {
+                        for (Bundle bundle : pending) {
                             sendMessage(bundle, FirebasexCorePlugin.getApplicationContext());
                         }
-                        notificationStack.clear();
                     } catch (Exception e) {
                         FirebasexCorePlugin.handleExceptionWithoutContext(e);
                     }


### PR DESCRIPTION
## Problem

Two related races in `FirebasexMessagingPlugin.java` cause FCM notifications to be lost (or, less often, duplicated) when the user cold-starts the app by tapping a system notification on Android S+ (API 31+).

### 1. `pluginInitialize()` misses notifications routed via `OnNotificationReceiverActivity`

On Android S+, `PendingIntent`s targeting a `BroadcastReceiver` are restricted, so notification taps are routed through `OnNotificationReceiverActivity` (which is the path declared in `plugin.xml` for the tap target). That activity calls `sendMessage(bundle, context)`, then launches the host activity — but in doing so it strips `google.message_id` from the extras and replaces it with the plugin's own `messageType` + `tap` keys.

When the host activity then starts and `pluginInitialize()` runs, the existing launch-extras check only looks for `google.message_id`:

```java
if (extras.containsKey("google.message_id")) {
    extras.putString("messageType", "notification");
    extras.putString("tap", "background");
    notificationStack.add(extras);
    ...
}
```

So it never re-queues the payload. If the JS callback was not yet registered when `sendMessage()` ran (typical on cold start, since the WebView isn't ready), the notification is silently dropped.

### 2. `sendPendingNotifications()` clears the stack *after* iterating

```java
private synchronized void sendPendingNotifications() {
    if (notificationStack != null) {
        this.cordova.getThreadPool().execute(new Runnable() {
            public void run() {
                try {
                    for (Bundle bundle : notificationStack) {
                        sendMessage(bundle, FirebasexCorePlugin.getApplicationContext());
                    }
                    notificationStack.clear();
                } catch (Exception e) { ... }
            }
        });
    }
}
```

`sendMessage()` can re-queue a payload onto `notificationStack` (when no JS callback is registered yet, or the app is still considered backgrounded). Two failure modes follow:

- The trailing `clear()` wipes any item that was re-queued during the iteration — those notifications are lost.
- A second call to `sendPendingNotifications()` (e.g. another `FirebasexAppDidBecomeActive` broadcast) racing the first can hit `ConcurrentModificationException`.

## Fix

Both fixes are in `src/android/FirebasexMessagingPlugin.java`.

1. **`pluginInitialize()`** — also detect the `(messageType + tap)` shape produced by `OnNotificationReceiverActivity`, with an id/reference guard so we don't double-enqueue an entry that `sendMessage()` may already have pushed:

   ```java
   } else if (extras.containsKey("messageType") && extras.containsKey("tap")) {
       boolean alreadyQueued = false;
       if (notificationStack != null) {
           for (Bundle b : notificationStack) {
               if (b == extras || (extras.getString("id") != null && extras.getString("id").equals(b.getString("id")))) {
                   alreadyQueued = true;
                   break;
               }
           }
       }
       if (!alreadyQueued) {
           notificationStack.add(extras);
       }
   }
   ```

2. **`sendPendingNotifications()`** — snapshot the stack and `clear()` it *before* dispatching the worker, so re-queues during iteration survive for the next flush and concurrent calls cannot corrupt the list:

   ```java
   if (notificationStack != null && !notificationStack.isEmpty()) {
       final ArrayList<Bundle> pending = new ArrayList<>(notificationStack);
       notificationStack.clear();
       this.cordova.getThreadPool().execute(new Runnable() {
           public void run() {
               try {
                   for (Bundle bundle : pending) {
                       sendMessage(bundle, FirebasexCorePlugin.getApplicationContext());
                   }
               } catch (Exception e) { ... }
           }
       });
   }
   ```

## Reproduction (before the fix)

1. Build for Android 12+ (API 31+).
2. Force-stop the app.
3. Send an FCM notification message.
4. Tap the system notification → app cold-starts.
5. The `onMessageReceived` JS callback never fires (or fires only for some of the queued payloads if multiple are pending).

After the fix, the payload is delivered to `onMessageReceived` once the JS callback is registered, with `tap: "background"`.

## Test plan

- [ ] Cold-start tap on Android 12+ delivers the notification to `onMessageReceived` exactly once.
- [ ] Cold-start tap on Android < 12 (BroadcastReceiver path) still works (regression check).
- [ ] App resumed from background with multiple queued notifications flushes all of them.
- [ ] No duplicate deliveries when the launch intent both contains `messageType+tap` extras *and* `sendMessage()` had already queued the same payload.

## Notes

- No public API change; pure internal correctness fix.
- iOS code path is unaffected.