### PR TITLE
Add types field to package.json for TypeScript resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
       }
     }
   },
+  "types": "types/index.d.ts",
   "dependencies": {
     "cordova-plugin-firebasex-core": "^1.0.0"
   }


### PR DESCRIPTION
The package contains a types definition file but is not referenced in package.json. This way, typescript will not recognize it by default.